### PR TITLE
Import DiscoverRunner for django 1.8 support

### DIFF
--- a/djnose2/runner.py
+++ b/djnose2/runner.py
@@ -4,13 +4,18 @@ from contextlib import contextmanager
 import logging
 
 from django.test import simple
+try:
+    from django.test.runner import DiscoverRunner
+except ImportError:
+    # Django < 1.8
+    from django.test.simple import DjangoTestSuiteRunner as DiscoverRunner
 from nose2.main import discover
 
 
 log = logging.getLogger(__name__)
 
 
-class TestRunner(simple.DjangoTestSuiteRunner):
+class TestRunner(DiscoverRunner):
 
     err_count = 0
     _hooks = ('startTestRun', 'reportFailure', 'reportError')

--- a/djnose2/runner.py
+++ b/djnose2/runner.py
@@ -3,7 +3,6 @@ import sys
 from contextlib import contextmanager
 import logging
 
-from django.test import simple
 try:
     from django.test.runner import DiscoverRunner
 except ImportError:


### PR DESCRIPTION
This is the same way that django-nose imports DiscoverRunner and
falls back to DjangoTestSuiteRunner on older versions of django.

refs #2
